### PR TITLE
Fix order-service Dockerfile build output and entrypoint

### DIFF
--- a/order-service/Dockerfile
+++ b/order-service/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.24.5 as builder
 WORKDIR /app
 COPY . .
 
-RUN go build -o . /app/app
+RUN go build -o /app/order-service ./order-service
 
 FROM gcr.io/distroless/base
-COPY --from=builder /app/order-service /app/order-service 
-ENTRYPOINT ["/app/app "]
+COPY --from=builder /app/order-service /app/order-service
+ENTRYPOINT ["/app/order-service"]


### PR DESCRIPTION
## Summary
- build order-service binary explicitly in Dockerfile
- run order-service binary as container entrypoint

## Testing
- `go test ./...` *(fails: conversion from int to string yields a string of one rune, not a string of digits)*

------
https://chatgpt.com/codex/tasks/task_e_6895246b6674832382ffdf030c9105e2