### PR TITLE
chore: pin distroless base image versions

### DIFF
--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -5,6 +5,6 @@ COPY . .
 
 RUN go build -o common ./common
 
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/base-debian11
 COPY --from=builder /app/common /app/app
 ENTRYPOINT ["/app/app"]

--- a/delivery-service/Dockerfile
+++ b/delivery-service/Dockerfile
@@ -5,6 +5,6 @@ COPY . .
 
 RUN go build -o delivery-service ./delivery-service
 
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/base-debian11
 COPY --from=builder /app/delivery-service /app/app
 ENTRYPOINT ["/app/app"]

--- a/kitchen-service/Dockerfile
+++ b/kitchen-service/Dockerfile
@@ -5,6 +5,6 @@ COPY . .
 
 RUN go build -o kitchen-service ./kitchen-service
 
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/base-debian11
 COPY --from=builder /app/kitchen-service /app/app
 ENTRYPOINT ["/app/app"]

--- a/order-service/Dockerfile
+++ b/order-service/Dockerfile
@@ -5,6 +5,6 @@ COPY . .
 
 RUN go build -o . /app/app
 
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/base-debian11
 COPY --from=builder /app/order-service /app/order-service 
 ENTRYPOINT ["/app/app "]


### PR DESCRIPTION
## Summary
- use `gcr.io/distroless/base-debian11` in all Dockerfiles instead of floating `gcr.io/distroless/base`

## Testing
- `go test ./...` *(fails: conversion from int to string in order-service)*

------
https://chatgpt.com/codex/tasks/task_e_68952452a6d88323aa7f6ea812a9c1d9